### PR TITLE
install: Make some improvements for when mt-tools are prebuilt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ install-git-scripts: svn2git split2mono
 	@echo "Installation succeeded: 'git apple-llvm' is now available!"
 
 svn2git split2mono:
-	make -C src D="$(LIBEXEC_DIR)/tools" $(LIBEXEC_DIR)/tools/$@
+	make -C src D="$(LIBEXEC_DIR)" $(LIBEXEC_DIR)/$@
 
 uninstall:
 	@echo "Uninstalling 'git-apple-llvm'"

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ $(VIRTUALENV):
 	python3 -m venv $(PREFIX)
 	@echo ""
 
-LIBEXEC_DIR=$(DESTDIR)$(PREFIX)/libexec/apple-llvm
+LIBEXEC_DIR := $(DESTDIR)$(PREFIX)/libexec/apple-llvm
 
 install-git-scripts: svn2git split2mono
 	@echo "Installing 'git apple-llvm' bash scripts"

--- a/libexec/apple-llvm/helpers/build_executable.sh
+++ b/libexec/apple-llvm/helpers/build_executable.sh
@@ -1,8 +1,15 @@
 build_executable() {
     local name="$1"
-    if [ -x "$APPLE_LLVM_LIBEXEC_DIR"/tools/"$name" ]; then
-        # Prebuilt executable (ie, we're installed)
-        echo "$APPLE_LLVM_LIBEXEC_DIR"/tools/"$name"
+
+    # Check for an override from the environment, used by tests, falling back
+    # to libexec/apple-llvm, used by installed tools.
+    local prebuiltdir="$APPLE_LLVM_PREBUILT_DIR"
+    [ -n "$prebuiltdir" ] || prebuiltdir="$APPLE_LLVM_LIBEXEC_DIR"/tools
+
+    # Return early if there's nothing to build.
+    local execpath="$prebuiltdir"/"$name"
+    if [ -x "$execpath" ]; then
+        echo "$execpath"
         return 0
     fi
 
@@ -23,7 +30,7 @@ build_executable() {
 
     local pd="$TMPDIR"mt-build-executable
     local d="$pd/$sha1"
-    local execpath="$d"/"$name"
+    execpath="$d"/"$name"
     if [ -x "$execpath" ]; then
         echo "$execpath"
         return 0

--- a/libexec/apple-llvm/helpers/build_executable.sh
+++ b/libexec/apple-llvm/helpers/build_executable.sh
@@ -1,8 +1,8 @@
 build_executable() {
     local name="$1"
-    if [ -x "$(dirname $0)"/tools/"$name" ]; then
+    if [ -x "$APPLE_LLVM_LIBEXEC_DIR"/tools/"$name" ]; then
         # Prebuilt executable (ie, we're installed)
-        echo "$(dirname $0)"/tools/"$name"
+        echo "$APPLE_LLVM_LIBEXEC_DIR"/tools/"$name"
         return 0
     fi
 

--- a/libexec/apple-llvm/helpers/build_executable.sh
+++ b/libexec/apple-llvm/helpers/build_executable.sh
@@ -4,7 +4,7 @@ build_executable() {
     # Check for an override from the environment, used by tests, falling back
     # to libexec/apple-llvm, used by installed tools.
     local prebuiltdir="$APPLE_LLVM_PREBUILT_DIR"
-    [ -n "$prebuiltdir" ] || prebuiltdir="$APPLE_LLVM_LIBEXEC_DIR"/tools
+    [ -n "$prebuiltdir" ] || prebuiltdir="$APPLE_LLVM_LIBEXEC_DIR"
 
     # Return early if there's nothing to build.
     local execpath="$prebuiltdir"/"$name"

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -27,5 +27,6 @@ config.environment['PATH'] = os.path.pathsep.join((python_root_dir, bindir, test
 
 # Add substitutions for built programs.
 builtdir = os.path.join(config.test_source_root, 'Built')
+config.environment['APPLE_LLVM_PREBUILT_DIR'] = builtdir
 config.substitutions.append(('%split2mono', os.path.join(builtdir, 'split2mono')))
 config.substitutions.append(('%svn2git', os.path.join(builtdir, 'svn2git')))


### PR DESCRIPTION
This would address my suggestions from https://github.com/apple/apple-llvm-infrastructure-tools/pull/68.  I put the commit to drop `tools/` last in case there was a reason you wanted a subdirectory there.